### PR TITLE
Add instructions and add duckdb lib

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,82 @@
+# AI Assistant Instructions for Public Images Repository
+
+## Repository Purpose
+This repo builds layered Docker images for data science environments:
+- `datascience.docker` - Base Python/ML environment with security-hardened tooling
+- `rust-datascience.docker` - Extends base with Rust ecosystem 
+- `net-datascience.docker` - Extends base with .NET SDKs and interactive kernels
+
+Built images are published as `mikaeluman/datascience:*` for reuse across projects.
+
+## Architecture Principles
+
+### Layered Image Strategy
+- **Base image**: `datascience.docker` contains foundational tools (Python, AWS CLI, k8s tools)
+- **Language extensions**: `rust-datascience.docker` and `net-datascience.docker` build FROM the base
+- **Shared components**: Common tooling installed once in base layer for efficiency
+
+### Security-First Binary Installation
+All downloaded binaries use cryptographic verification:
+- **AWS CLI**: GPG signature verification with pinned public key (`awscliv2-public-key.asc`)
+- **Kubernetes tools**: SHA256 checksum verification from official sources
+- **Pattern**: `ARG VERSION` → `curl binary + checksum` → `verify` → `install` → `cleanup`
+
+## Critical Conventions
+
+### User/Root Installation Pattern
+```dockerfile
+# System packages as root
+RUN apt-get install system-packages
+# Switch to user for dev tools  
+USER $USER
+# Language toolchains/packages as user
+RUN uv add python-packages / cargo install tools
+```
+
+### Version Pinning Strategy
+- All tools use `ARG VERSION=x.y.z` for easy updates
+- Labels track installed versions: `org.opencontainers.image.tool.version=${VERSION}`
+- PyTorch CPU-only via `pytorch.toml` configuration (toggleable with `USE_TORCH_GPU` build arg)
+
+### Python Environment Management
+- **uv** (not pip) for all Python package management
+- Environment variables: `UV_COMPILE_BYTECODE=1`, `UV_LINK_MODE=copy`, `UV_PYTHON_PREFERENCE=only-managed`
+- Jupyter kernels installed both per-user and globally (`/usr/local/share/jupyter/kernels`)
+
+### Rust Toolchain Integration
+- Install via `rustup` as user, not system packages
+- Cache mounts for `$USER/.cargo/registry` and `$USER/.cargo/git` 
+- Components via `rustup component add`, tools via `cargo install`
+
+### .NET Multi-SDK Setup
+- Multiple SDK versions: `DOTNET_SDK_VERSIONS="8.0 9.0"`
+- Global tool installation to `/usr/local/bin` for system-wide access
+- Jupyter kernel registration for interactive notebooks
+
+## Development Workflow
+
+### Building Images
+```bash
+# Base image first
+docker build -f datascience.docker -t mikaeluman/datascience:latest .
+
+# Then language extensions
+docker build -f rust-datascience.docker -t mikaeluman/datascience:rust .
+docker build -f net-datascience.docker -t mikaeluman/datascience:net .
+```
+
+### Version Updates
+1. Update `ARG VERSION=x.y.z` declarations
+2. Test build locally  
+3. Verify tool versions: `docker run --rm image:tag tool --version`
+4. Update labels match ARG values
+
+### Security Maintenance
+- Check `awscliv2-public-key.asc` fingerprint against AWS docs when updating AWS CLI
+- Verify SHA256 sources for k8s tools remain official
+- Monitor base image CVEs: `ubuntu:24.04`
+
+## Key Files to Understand
+- `pytorch.toml` - uv configuration for CPU-only PyTorch (prevents GPU dependencies)
+- `awscliv2-public-key.asc` - AWS CLI public key for signature verification
+- `ARG USE_TORCH_GPU=false` - Build-time toggle for PyTorch variant selection

--- a/datascience.docker
+++ b/datascience.docker
@@ -82,7 +82,7 @@ RUN set -eux; \
     rm -rf /tmp/*
 
 # install duckdb CLI into /usr/local/bin (on PATH)
-ARG DUCKDB_VERSION=1.4.0
+ARG DUCKDB_VERSION=1.4.2
 ARG DUCKDB_ASSET="duckdb_cli-linux-amd64.gz"
 RUN set -eux; \
     curl -fsSL -o /tmp/${DUCKDB_ASSET} "https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.gz"; \

--- a/rust-datascience.docker
+++ b/rust-datascience.docker
@@ -2,13 +2,30 @@ FROM mikaeluman/datascience:latest
 
 USER root
 
-# deps needed to build crates
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
       build-essential pkg-config cmake \
       libssl-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev libsnappy-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Duckdb pre-built library.
+RUN set -eux; \
+    DUCKDB_VERSION="v1.4.2"; \
+    curl -L "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/libduckdb-linux-amd64.zip" -o /tmp/libduckdb.zip; \
+    mkdir -p /opt/duckdb; \
+    unzip /tmp/libduckdb.zip -d /opt/duckdb; \
+    rm /tmp/libduckdb.zip; \
+    # files now in /opt/duckdb: libduckdb.so, libduckdb_static.a, duckdb.h, duckdb.hpp
+    cp /opt/duckdb/libduckdb.so /usr/local/lib/; \
+    mkdir -p /usr/local/include; \
+    cp /opt/duckdb/duckdb.h /usr/local/include/; \
+    cp /opt/duckdb/duckdb.hpp /usr/local/include/; \
+    ldconfig
+
+# Tell libduckdb-sys where to look (for the Rust crate)
+ENV DUCKDB_LIB_DIR=/usr/local/lib \
+    DUCKDB_INCLUDE_DIR=/usr/local/include
 
 ENV CARGO_HOME=/home/$USER/.cargo \
     RUSTUP_HOME=/home/$USER/.rustup \


### PR DESCRIPTION
Add copilot instructions and change so duckdb is installed with pre-built libraries so we don't have to compile them manually which has been problematic due to constant rebuilds inside the container.